### PR TITLE
Fix for pip>21.1.3

### DIFF
--- a/pippel.py
+++ b/pippel.py
@@ -3,23 +3,40 @@ import os
 import sys
 from typing import Dict, List, Optional
 
-from pip import __version__ as pipver
+# Parse current Pip version
+from pip import __version__ as __pipver
+pipver = tuple(map(int, __pipver.split('.')))
+if len(pipver) == 2:
+    pipver = (*pipver, 0)
 
-# For older versions of pip
-try:
+
+def compare_version(version_a, version_b):
+    # type: (tuple, tuple) -> bool
+    """
+    Compares version tuples.
+    Returns True if VERSION_A is greater than or equal to VERSION_B.
+    """
+    for rank_a, rank_b in zip(version_a, version_b):
+        if rank_a != rank_b:
+            return True if rank_a > rank_b else False
+    return True
+
+
+# Module imports depend on Pip version.
+if compare_version((19, 1, 1), pipver):
     from pip.commands.install import InstallCommand
     from pip.commands.list import ListCommand
     from pip.commands.show import search_packages_info
     from pip.commands.uninstall import UninstallCommand
     from pip.utils import get_installed_distributions
-
-# For newer versions of pip
-except ImportError:
+else:
+    if compare_version((21, 2, 3), pipver):
+        # get_installed_distributions is removed from 21.3
+        from pip._internal.utils.misc import get_installed_distributions
     from pip._internal.commands.install import InstallCommand
     from pip._internal.commands.list import ListCommand
     from pip._internal.commands.show import search_packages_info
     from pip._internal.commands.uninstall import UninstallCommand
-    from pip._internal.utils.misc import get_installed_distributions
 
 
 class Server(object):
@@ -38,12 +55,14 @@ class Server(object):
         self.stdout.flush()
 
     def read_json(self):
+        # type: () -> dict
         line = self.stdin.readline()
         if not line:
             raise EOFError()
         return json.loads(line)
 
     def handle_request(self):
+        # type: () -> None
         request = self.read_json()
         method = request["method"]
         params = request["params"]
@@ -75,7 +94,7 @@ class PipBackend(Server):
     def in_virtual_env():
         # type: () -> bool
         """
-        Returns TRUE if package is run while in a virtual environment
+        Returns TRUE if package is run while in a virtual environment.
         """
         if hasattr(sys, "base_prefix"):
             return sys.base_prefix != sys.prefix
@@ -86,50 +105,72 @@ class PipBackend(Server):
 
     def get_installed_packages(self):
         # type: () -> List[Dict[str, str]]
-        try:
+        """
+        Retrieves all the installed packages in current environment as a dictionary.
+        """
+        if compare_version((19, 1, 0), pipver):
             get_list = ListCommand()
-        except TypeError:
+        else:
             get_list = ListCommand("Pippel",
                                    "Backend server for the Pippel service.")
         options, args = get_list.parse_args(["--outdated"])
-        packages = [package for package in get_installed_distributions()
-                    if package.key != "team"]
-        final = [
-            {"name": attributes.get("name"),
-             "version": attributes.get("version"),
-             "latest": str(getattr(package, "latest_version")),
-             "summary": attributes.get("summary"),
-             "home-page": attributes.get("home-page")
-            }
-            for package in get_list.iter_packages_latest_infos(packages, options)
-            for attributes in search_packages_info([package.key])  # noqa
-        ]
-        # TODO: To profile performance speed of snippet above and below.
-        # final = [
-        #     {"name": attributes.get("name"),
-        #      "version": attributes.get("version"),
-        #      "latest": str(getattr(latest_info, "latest_version")),
-        #      "summary": attributes.get("summary"),
-        #      "home-page": attributes.get("home-page")
-        #     }
-        #     for latest_info, attributes in zip(
-        #             [get_list.iter_packages_latest_infos(packages, options),
-        #              search_packages_info([getattr(package, "key")
-        #                                    for package in packages])]
-        #     )
-        # ]
+
+        if compare_version((21, 2, 0), pipver):
+            packages = [package for package in get_installed_distributions()
+                        if package.key != "team"]
+            final = [
+                {"name": attributes.get("name"),
+                "version": attributes.get("version"),
+                "latest": str(getattr(package, "latest_version")),
+                "summary": attributes.get("summary"),
+                "home-page": attributes.get("home-page")
+                }
+                for package in get_list.iter_packages_latest_infos(packages, options)
+                for attributes in search_packages_info([package.key])
+            ]
+        else:
+            # Pip 21.2 onwards use _ProcessedDists class to contain all the metadata of
+            # a package instead of a dictionary.
+            from pip._internal.utils.compat import stdlib_pkgs
+            from pip._internal.metadata import get_environment
+            from typing import cast
+
+            skip = set(stdlib_pkgs)
+            packages = [
+                cast("_DistWithLatestInfo", d)
+                for d in get_environment(options.path).iter_installed_distributions(
+                    local_only=options.local,
+                    user_only=options.user,
+                    editables_only=options.editable,
+                    include_editables=options.include_editable,
+                    skip=skip,
+                )
+            ]
+            final = [
+                {"name": str(getattr(attributes, "name")),
+                "version": str(getattr(attributes, "version")),
+                "latest": str(getattr(package, "latest_version")),
+                "summary": str(getattr(attributes, "summary")),
+                "home-page": str(getattr(attributes, "homepage"))
+                }
+                for package in get_list.iter_packages_latest_infos(packages, options)
+                for attributes in search_packages_info([package.canonical_name])
+            ]
         return final
 
     def install_package(self, packages, params=None):
         # type: (str, Optional[str]) -> int
-        try:
-            # For pip <= 19.1.1
+        """
+        Installs the string of packages and returns the success code.
+        """
+        if compare_version((19, 1, 0), pipver):
             install = InstallCommand()
-        except TypeError:
-            # For pip > 19.1.1
+        else:
             install = InstallCommand("Pippel",
                                      "Backend server for the Pippel service.")
+
         assert packages , "`packages` should not be an empty string."
+        success = 1
         for package in packages.split():
             if self.in_virtual_env():
                 args = [package, "--upgrade"]
@@ -137,22 +178,22 @@ class PipBackend(Server):
                 args = [package, "--upgrade", "--target", params]
             else:
                 args = [package, "--upgrade", "--user"]
-            k = install.main(args)
-        return k
+            success = install.main(args)
+        return success
 
     def remove_package(self, packages):
         # type: (str) -> int
-        packages = packages.split()
+        """
+        Removes the string of packages and returns the success code.
+        """
         assert packages , "`packages` should not be an empty string."
-        try:
-            # For pip <= 19.1.1
+        if compare_version((19, 1, 0), pipver):
             uninstall = UninstallCommand()
-        except TypeError:
-            # For pip > 19.1.1
+        else:
             uninstall = UninstallCommand("Pippel",
                                          "Backend server for the Pippel service.")
-        k = uninstall.main(packages + ["--yes"])
-        return k
+        success = uninstall.main(packages.split() + ["--yes"])
+        return success
 
 if __name__ == "__main__":
     stdin = sys.stdin


### PR DESCRIPTION
Fixes issue #17

Pip 21.2 onwards use _ProcessedDists class to contain all the metadata of a
package instead of a dictionary. This fix makes the necessary changes to account
for this.

A new function to compare pip versions is added to segment pippel.py script
according to the current environment's pip version.

Several typing hints and comments are added for clarity.

Signed-off-by: Arif Er <arifer612@pm.me>